### PR TITLE
Fix text line overlaps

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -101,6 +101,7 @@
 .station-info p {
   margin: 15px 0;
   padding: 5px 10px;
+  white-space: pre;
 }
 
 .wth-info {


### PR DESCRIPTION
### PTAL

Fixed line overlapping with `line-height` and `white-space`.